### PR TITLE
Add metadata for PyPI in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ readme = "README.md"
 version = "0.2.2"
 requires-python = ">=3.10"
 license = { text = "MIT" }
-description = "Tools for creating OPTIMADE APIs from static data."
-readme = "README.md"
 keywords = ["optimade", "jsonapi", "materials"]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,21 @@ description = "Tools for making OPTIMADE APIs from raw structural data."
 readme = "README.md"
 version = "0.2.2"
 requires-python = ">=3.10"
+license = { text = "MIT" }
+description = "Tools for creating OPTIMADE APIs from static data."
+readme = "README.md"
+keywords = ["optimade", "jsonapi", "materials"]
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Intended Audience :: Science/Research",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering",
+]
 
 dependencies = [
     "pydantic~=2.2",


### PR DESCRIPTION
Hey @eimrek, great work on `optimake serve` and the PyPI release, this PR just adds some info in the `pyproject.toml` that PyPI will use to populate the project page/search.