### PR TITLE
Loosen numpy and pandas deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ exclude: "scripts|src/optimade_launch"
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 24.10.0
     hooks:
     - id: black
       name: Blacken
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     - id: check-symlinks
     - id: check-yaml
@@ -26,13 +26,13 @@ repos:
       args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.270'
+    rev: 'v0.7.1'
     hooks:
     - id: ruff
       args: [--fix]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.13.0
     hooks:
     - id: mypy
       name: "MyPy"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
     hooks:
     - id: mypy
       name: "MyPy"
-      additional_dependencies: ["pydantic~=2.2"]
+      additional_dependencies: ["pydantic~=2.2", "types-PyYAML", "types-requests"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,4 @@ repos:
     hooks:
     - id: mypy
       name: "MyPy"
-      additional_dependencies: ["types-all", "pydantic~=1.10"]
+      additional_dependencies: ["pydantic~=2.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,13 @@ tests = ["pytest~=7.4", "pytest-cov~=4.0"]
 dev = ["black", "ruff", "pre-commit", "mypy", "isort"]
 
 [tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "W", "Q"]
 ignore = ["E501", "E402"]
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 unfixable = []
-target-version = "py311"
 per-file-ignores = {}
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pybtex~=0.24",
     "tqdm~=4.65",
     "requests~=2.31",
-    "numpy >= 1.26, < 3",
+    "numpy >= 1.22, < 3",
     "click~=8.1"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ dependencies = [
     "optimade[server,ase]~=1.1",
     "pyyaml~=6.0",
     "pymatgen>=2023.9",
-    "pandas~=2.1",
+    "pandas >= 1.5, < 3",
     "pybtex~=0.24",
     "tqdm~=4.65",
     "requests~=2.31",
-    "numpy~=1.26",
+    "numpy >= 1.26, < 3",
     "click~=8.1"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = ["pytest~=7.4", "pytest-cov~=4.0"]
-dev = ["black", "ruff", "pre-commit", "mypy", "isort", "types-all"]
+dev = ["black", "ruff", "pre-commit", "mypy", "isort"]
 
 [tool.ruff]
 select = ["E", "F", "I", "W", "Q"]

--- a/src/optimade_maker/archive/utils.py
+++ b/src/optimade_maker/archive/utils.py
@@ -1,4 +1,5 @@
 """Get file URLs from Materials Cloud records"""
+
 from __future__ import print_function
 
 import json

--- a/src/optimade_maker/config.py
+++ b/src/optimade_maker/config.py
@@ -14,8 +14,7 @@ import yaml
 from pydantic import BaseModel, Field
 
 
-class UnsupportedConfigVersion(RuntimeError):
-    ...
+class UnsupportedConfigVersion(RuntimeError): ...
 
 
 class PropertyDefinition(BaseModel):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from optimade.models import EntryInfoResource
+
 from optimade_maker.convert import convert_archive
 
 EXAMPLE_ARCHIVES = (Path(__file__).parent.parent / "examples").glob("*")

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from optimade_maker.config import Config
 
 EXAMPLE_YAMLS = (Path(__file__).parent.parent / "examples").glob("*/optimade.yaml")


### PR DESCRIPTION
Hi @eimrek, I am trying to use `optimake` as part of another project, which unfortunately requires me to use an older library that only supports pandas v1. As we only use pandas for `read_csv`, I think we can safely allow pandas?

The same is true for numpy, we only use it (explicitly) during testing, so we should free up the deps that might need v2 and see how it falls out.

I'm happy to add testing of minimum supported versions (via `uv`) if that would be useful too.