### PR TITLE
QoL changes to launching server and other fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @eimrek @ml-evs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           pre-commit run --all-files
 
       - name: Run tests
-        run: pytest -vv --cov-report=xml --cov-report=term ./tests
+        run: pytest -vv --cov=./src/optimade_maker --cov-report=xml --cov-report=term ./tests
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U setuptools wheel
-          pip install -e .[tests,dev]
+          pip install -e .[tests,dev,ingest]
 
       - name: Run linters
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: "scripts|src/optimade_launch"
 
 repos:
   - repo: https://github.com/ambv/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
     - id: black
       name: Blacken
@@ -26,13 +26,13 @@ repos:
       args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.7.1'
+    rev: 'v0.9.4'
     hooks:
     - id: ruff
       args: [--fix]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.1
     hooks:
     - id: mypy
       name: "MyPy"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@
 
 # <div align="center">optimade-maker</div>
 
+<div align="center">
+
 [![PyPI - Version](https://img.shields.io/pypi/v/optimade-maker?color=4CC61E)](https://pypi.org/project/optimade-maker/)
+![PyPI - License](https://img.shields.io/pypi/l/optimade-maker?color=blue)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/materialscloud-org/optimade-maker/ci.yml)
+
+</div>
 
 Tools for making [OPTIMADE APIs](https://optimade.org) from various formats of structural data (e.g. an archive of CIF files).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-ingest = ["ase ~= 3.22", "pymatgen >= 2023.9", "pandas >= 1.5, < 3"]
+ase = ["ase ~= 3.22"]
+pymatgen = ["pymatgen >= 2023.9"]
+pandas = ["pandas >= 1.5, < 3"]
+ingest = ["optimade-maker[ase,pymatgen,pandas]"]
 tests = ["pytest~=8.3", "pytest-cov~=6.0"]
 dev = ["black", "ruff", "pre-commit", "mypy", "isort"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = ["pytest~=7.4", "pytest-cov~=4.0"]
+tests = ["pytest~=8.3", "pytest-cov~=6.0"]
 dev = ["black", "ruff", "pre-commit", "mypy", "isort"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "pyyaml~=6.0",
     "pymatgen>=2023.9",
     "pandas >= 1.5, < 3",
-    "pybtex~=0.24",
     "tqdm~=4.65",
     "requests~=2.31",
     "numpy >= 1.22, < 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "optimade-maker"
 description = "Tools for making OPTIMADE APIs from raw structural data."
 readme = "README.md"
 version = "0.3.0"
-requires-python = ">=3.10"
+requires-python = ">= 3.10, < 3.13"
 license = { text = "MIT" }
 keywords = ["optimade", "jsonapi", "materials"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,8 @@ classifiers = [
 
 dependencies = [
     "pydantic~=2.2",
-    "optimade[server,ase]~=1.1",
+    "optimade[server]~=1.1",
     "pyyaml~=6.0",
-    "pymatgen>=2023.9",
-    "pandas >= 1.5, < 3",
     "tqdm~=4.65",
     "requests~=2.31",
     "numpy >= 1.22, < 3",
@@ -31,6 +29,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+ingest = ["ase ~= 3.22", "pymatgen >= 2023.9", "pandas >= 1.5, < 3"]
 tests = ["pytest~=8.3", "pytest-cov~=6.0"]
 dev = ["black", "ruff", "pre-commit", "mypy", "isort"]
 

--- a/src/optimade_maker/cli.py
+++ b/src/optimade_maker/cli.py
@@ -22,11 +22,16 @@ def cli():
     type=click.Path(),
     help="The path to write the JSONL file to.",
 )
+@click.option(
+    "--limit",
+    type=int,
+    help="Limit the ingestion to a fixed number of structures (useful for testing)."
+)
 @click.argument(
     "path",
     type=click.Path(),
 )
-def convert(jsonl_path, path):
+def convert(jsonl_path, path, limit=None):
     """
     Convert a raw data archive into OPTIMADE JSONL.
 
@@ -38,8 +43,7 @@ def convert(jsonl_path, path):
         jsonl_path = Path(jsonl_path)
         if jsonl_path.exists():
             raise FileExistsError(f"File already exists at {jsonl_path}.")
-
-    convert_archive(Path(path), jsonl_path=jsonl_path)
+    convert_archive(Path(path), jsonl_path=jsonl_path, limit=limit)
 
 
 @cli.command()

--- a/src/optimade_maker/cli.py
+++ b/src/optimade_maker/cli.py
@@ -25,7 +25,7 @@ def cli():
 @click.option(
     "--limit",
     type=int,
-    help="Limit the ingestion to a fixed number of structures (useful for testing)."
+    help="Limit the ingestion to a fixed number of structures (useful for testing).",
 )
 @click.argument(
     "path",

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -16,7 +16,6 @@ from optimade.models import EntryInfoResource, EntryResource
 from optimade.server.schemas import ENTRY_INFO_SCHEMAS, retrieve_queryable_properties
 
 from .config import Config, EntryConfig, JSONLConfig, ParsedFiles, PropertyDefinition
-from .parsers import ENTRY_PARSERS, OPTIMADE_CONVERTERS, PROPERTY_PARSERS, TYPE_MAP
 
 PROVIDER_PREFIX = os.environ.get("OPTIMAKE_PROVIDER_PREFIX", "optimake")
 
@@ -55,7 +54,9 @@ def _construct_entry_type_info(
     return EntryInfoResource(**info)
 
 
-def convert_archive(archive_path: Path, jsonl_path: Path | None = None, limit: int | None = None) -> Path:
+def convert_archive(
+    archive_path: Path, jsonl_path: Path | None = None, limit: int | None = None
+) -> Path:
     """Convert an MCloud entry to an OPTIMADE JSONL file.
 
     Parameters:
@@ -107,7 +108,9 @@ def convert_archive(archive_path: Path, jsonl_path: Path | None = None, limit: i
 
     for entry in mc_config.entries:
         optimade_entries[entry.entry_type].extend(
-            construct_entries(archive_path, entry, PROVIDER_PREFIX, limit=limit).values()
+            construct_entries(
+                archive_path, entry, PROVIDER_PREFIX, limit=limit
+            ).values()
         )
 
     property_definitions = defaultdict(list)
@@ -243,13 +246,17 @@ def _parse_entries(
         A list of parsed entries and a list of IDs.
 
     """
+    from .parsers import ENTRY_PARSERS
+
     parsed_entries = []
     entry_ids: list[str] = []
     for archive_file in matches_by_file:
-        for ind, _path in enumerate(tqdm.tqdm(
-            matches_by_file[archive_file],
-            desc=f"Parsing {entry_type} files",
-        )):
+        for ind, _path in enumerate(
+            tqdm.tqdm(
+                matches_by_file[archive_file],
+                desc=f"Parsing {entry_type} files",
+            )
+        ):
             if limit and ind >= limit:
                 break
 
@@ -362,6 +369,8 @@ def _parse_and_assign_properties(
     dictionary of OPTIMADE entries.
 
     """
+    from .parsers import PROPERTY_PARSERS, TYPE_MAP
+
     parsed_properties: dict[str, dict[str, Any]] = defaultdict(dict)
     errors = []
     all_property_fields: set[str] = set()
@@ -432,7 +441,10 @@ def _parse_and_assign_properties(
 
 
 def construct_entries(
-    archive_path: Path, entry_config: EntryConfig, provider_prefix: str, limit: int | None = None,
+    archive_path: Path,
+    entry_config: EntryConfig,
+    provider_prefix: str,
+    limit: int | None = None,
 ) -> dict[str, dict]:
     """Given an archive path and an entry specification,
     loop through the provided paths and try to ingest them
@@ -446,6 +458,8 @@ def construct_entries(
             the given entry type.
 
     """
+
+    from .parsers import ENTRY_PARSERS, OPTIMADE_CONVERTERS
 
     if entry_config.entry_type not in ENTRY_PARSERS:
         raise RuntimeError(f"Parsing type {entry_config.entry_type} is not supported.")

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -18,7 +18,7 @@ from optimade.server.schemas import ENTRY_INFO_SCHEMAS, retrieve_queryable_prope
 from .config import Config, EntryConfig, JSONLConfig, ParsedFiles, PropertyDefinition
 from .parsers import ENTRY_PARSERS, OPTIMADE_CONVERTERS, PROPERTY_PARSERS, TYPE_MAP
 
-PROVIDER_PREFIX = os.environ.get("optimake_PROVIDER_PREFIX", "optimake")
+PROVIDER_PREFIX = os.environ.get("OPTIMAKE_PROVIDER_PREFIX", "optimake")
 
 
 def _construct_entry_type_info(

--- a/src/optimade_maker/logger.py
+++ b/src/optimade_maker/logger.py
@@ -1,9 +1,4 @@
 import logging
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
-
 LOGGER = logging.getLogger("optimake")
+LOGGER.setLevel(logging.INFO)

--- a/src/optimade_maker/parsers.py
+++ b/src/optimade_maker/parsers.py
@@ -3,7 +3,6 @@ from typing import Any, Callable
 
 import ase.io
 import pandas
-import pybtex.database
 import pymatgen.core
 import pymatgen.entries.computed_entries
 from optimade.adapters import Structure
@@ -11,10 +10,6 @@ from optimade.models import EntryResource
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 
 from optimade_maker.config import PropertyDefinition
-
-
-def pybtex_to_optimade(bib_entry: Any, properties=None) -> EntryResource:
-    raise NotImplementedError
 
 
 def load_csv_file(
@@ -118,7 +113,6 @@ ENTRY_PARSERS: dict[str, list[Callable[[Path], Any]]] = {
         ),
         wrapped_json_parser(pymatgen.core.Structure.from_dict),
     ],
-    "references": [pybtex.database.parse_file],
 }
 
 
@@ -159,5 +153,4 @@ OPTIMADE_CONVERTERS: dict[
     str, list[Callable[[Any, list[PropertyDefinition] | None], EntryResource | dict]]
 ] = {
     "structures": [structure_ingest_wrapper, parse_computed_structure_entry],
-    "references": [pybtex_to_optimade],
 }

--- a/src/optimade_maker/parsers.py
+++ b/src/optimade_maker/parsers.py
@@ -1,13 +1,19 @@
 from pathlib import Path
 from typing import Any, Callable
 
-import ase.io
-import pandas
-import pymatgen.core
-import pymatgen.entries.computed_entries
+try:
+    import ase.io
+    import pandas
+    import pymatgen.core
+    import pymatgen.entries.computed_entries
+    from pymatgen.entries.computed_entries import ComputedStructureEntry
+except ImportError as exc:
+    raise ImportError(
+        "The parsers module requires the `ingest` extra of this package to be installed."
+    ) from exc
+
 from optimade.adapters import Structure
 from optimade.models import EntryResource
-from pymatgen.entries.computed_entries import ComputedStructureEntry
 
 from optimade_maker.config import PropertyDefinition
 

--- a/src/optimade_maker/serve.py
+++ b/src/optimade_maker/serve.py
@@ -140,6 +140,7 @@ class OptimakeServer:
             "debug": False,
             "insert_test_data": False,
             "insert_from_jsonl": str(jsonl_path.resolve()),
+            "create_default_index": True,
             "base_url": self.base_url,
             "provider": get_optimake_provider_info(),
             # "index_base_url": self.index_base_url,

--- a/src/optimade_maker/serve.py
+++ b/src/optimade_maker/serve.py
@@ -101,9 +101,18 @@ class OptimakeServer:
     Uses the MongoMock backend.
     """
 
-    def __init__(self, path: Path, port: int = 5000):
+    def __init__(self, path: Path, port: int = 5000, **config_kws):
+        """Initialise the OptimakeServer instance.
+
+        Parameters:
+            path: Path to the directory containing the optimade.jsonl file.
+            port: Port to run the API on.
+            config_kws: Additional optimade-python-tools configuration options to pass to the API.
+
+        """
         self.path = path
         self.port = port
+        self.config_kws = config_kws
 
         self.base_url = f"http://localhost:{self.port}"
         # self.index_base_url = "http://localhost:5001"
@@ -125,6 +134,8 @@ class OptimakeServer:
             "provider_fields": provider_fields,
             "log_dir": str(self.path.resolve()),
         }
+
+        config_dict.update(self.config_kws)
 
         LOGGER.debug(f"CONFIG: {config_dict}")
 

--- a/src/optimade_maker/serve.py
+++ b/src/optimade_maker/serve.py
@@ -40,6 +40,8 @@ def set_config_env_variables(config_dict):
         env_var = f"OPTIMADE_{key}"
         if isinstance(value, (dict, list, bool)):
             os.environ[env_var] = json.dumps(value)
+        elif value is None:
+            os.environ[env_var] = "null"
         else:
             os.environ[env_var] = str(value)
 

--- a/src/optimade_maker/serve.py
+++ b/src/optimade_maker/serve.py
@@ -150,6 +150,16 @@ class OptimakeServer:
 
         config_dict.update(self.config_kws)
 
+        # Loop through any environment variables that start with "OPTIMAKE_" and set them
+        for env in os.environ:
+            if env.startswith("OPTIMAKE_"):
+                LOGGER.debug(
+                    "Reading environment variable %s into config with value %s",
+                    env,
+                    os.environ[env],
+                )
+                config_dict[env.replace("OPTIMAKE_", "").lower()] = os.environ[env]
+
         LOGGER.debug(f"CONFIG: {config_dict}")
 
         return config_dict


### PR DESCRIPTION
- Allow config to be passed programmatically
- Use new optimade-python-tools option for creating indices by default
- Better warnings on initial JSONL ingestion
- Add upper Python version pin to 3.13, as pymatgen does not support it (but they accidentally released a PyPI version that said they did, so things don't quite work as they're meant to)
- Remove pybtex: we never added any code that uses this, and pybtex is now very out of date (and leads to errors for packaging).
- Added a CODEOWNERS file
- Allow the user to override the underlying OPTIMADE server config by using `OPTIMAKE_` prefixed env vars
- Fix coverage in CI