### PR TITLE
Use dynamic versioning to take git tag as version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 name = "optimade-maker"
 description = "Tools for making OPTIMADE APIs from raw structural data."
 readme = "README.md"
-version = "0.3.0"
 requires-python = ">= 3.10, < 3.13"
 license = { text = "MIT" }
 keywords = ["optimade", "jsonapi", "materials"]
+dynamic = ["version"]
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -27,6 +27,14 @@ dependencies = [
     "numpy >= 1.22, < 3",
     "click~=8.1"
 ]
+
+[build-system]
+requires = ["setuptools >= 62", "setuptools_scm ~= 8.1", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"
+version_scheme = "post-release"
 
 [project.optional-dependencies]
 ase = ["ase ~= 3.22"]


### PR DESCRIPTION
I first messed up the v0.4.0 release by not incrementing the version number. This PR adds `setuptools_scm` to generate the version number directly from the git tag.