### PR TITLE
Add `overwrite` flag to `optimake convert`

### DIFF
--- a/src/optimade_maker/cli.py
+++ b/src/optimade_maker/cli.py
@@ -17,6 +17,10 @@ def cli():
 
 
 @cli.command()
+@click.argument(
+    "path",
+    type=click.Path(),
+)
 @click.option(
     "--jsonl_path",
     type=click.Path(),
@@ -27,11 +31,12 @@ def cli():
     type=int,
     help="Limit the ingestion to a fixed number of structures (useful for testing).",
 )
-@click.argument(
-    "path",
-    type=click.Path(),
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    help="Overwrite the JSONL file if it already exists.",
 )
-def convert(jsonl_path, path, limit=None):
+def convert(path, jsonl_path, limit=None, overwrite=False):
     """
     Convert a raw data archive into OPTIMADE JSONL.
 
@@ -43,7 +48,7 @@ def convert(jsonl_path, path, limit=None):
         jsonl_path = Path(jsonl_path)
         if jsonl_path.exists():
             raise FileExistsError(f"File already exists at {jsonl_path}.")
-    convert_archive(Path(path), jsonl_path=jsonl_path, limit=limit)
+    convert_archive(Path(path), jsonl_path=jsonl_path, limit=limit, overwrite=overwrite)
 
 
 @cli.command()

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -64,7 +64,10 @@ def _construct_entry_type_info(
 
 
 def convert_archive(
-    archive_path: Path, jsonl_path: Path | None = None, limit: int | None = None
+    archive_path: Path,
+    jsonl_path: Path | None = None,
+    limit: int | None = None,
+    overwrite: bool = False,
 ) -> Path:
     """Convert an MCloud entry to an OPTIMADE JSONL file.
 
@@ -96,7 +99,10 @@ def convert_archive(
         if jsonl_path != src_jsonl_path:
             # add a symlink to the specified jsonl_path
             if jsonl_path.exists():
-                raise RuntimeError(f"Not overwriting existing file at {jsonl_path}")
+                if overwrite:
+                    jsonl_path.unlink()
+                else:
+                    raise RuntimeError(f"Not overwriting existing file at {jsonl_path}")
             jsonl_path.symlink_to(archive_path / src_jsonl_path)
         return jsonl_path
 
@@ -132,6 +138,7 @@ def convert_archive(
         property_definitions,
         PROVIDER_PREFIX,
         jsonl_path,
+        overwrite,
     )
 
     return jsonl_path
@@ -563,6 +570,7 @@ def write_optimade_jsonl(
     property_definitions: dict[str, list[PropertyDefinition]],
     provider_prefix: str,
     jsonl_path: Path | None = None,
+    overwrite: bool = False,
 ) -> Path:
     """Write OPTIMADE entries to a JSONL file.
 
@@ -583,10 +591,10 @@ def write_optimade_jsonl(
     if not jsonl_path:
         jsonl_path = archive_path / "optimade.jsonl"
 
-    if jsonl_path.exists():
+    if jsonl_path.exists() and not overwrite:
         raise RuntimeError(f"Not overwriting existing file at {jsonl_path}")
 
-    with open(jsonl_path, "a") as jsonl:
+    with open(jsonl_path, "w") as jsonl:
         # write the optimade jsonl header
         header = {"x-optimade": {"meta": {"api_version": OPTIMADE_API_VERSION}}}
         jsonl.write(json.dumps(header))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -24,10 +24,12 @@ def test_convert_example_archives(archive_path, tmp_path):
     tmp_path = tmp_path / archive_path.name
     shutil.copytree(archive_path, tmp_path)
 
-    jsonl_path = convert_archive(tmp_path)
+    jsonl_path = convert_archive(tmp_path, overwrite=True)
     assert jsonl_path.exists()
 
-    jsonl_path_custom = convert_archive(tmp_path, jsonl_path=tmp_path / "test.jsonl")
+    jsonl_path_custom = convert_archive(
+        tmp_path, jsonl_path=tmp_path / "test.jsonl", overwrite=True
+    )
     assert jsonl_path_custom.exists()
 
     first_entry_path = archive_path / ".testing" / "first_entry.json"


### PR DESCRIPTION
Add a simple `overwrite` flag to convert that might be useful, e.g. when testing (so that one doesn't have to manually delete the jsonl file when trying to recreate it).