### PR TITLE
Usability tweaks

### DIFF
--- a/src/optimade_maker/config.py
+++ b/src/optimade_maker/config.py
@@ -3,8 +3,10 @@ to indicate how an OPTIMADE API should be constructed from the entry.
 
 """
 
+from optimade.models.optimade_json import DataType
 from pydantic import ConfigDict, field_validator, model_validator
 
+IDENTIFIER_REGEX = r"^[a-z_][a-z_0-9]*$"
 __version__ = "0.1.0"
 
 from pathlib import Path
@@ -24,9 +26,10 @@ class PropertyDefinition(BaseModel):
     """
 
     name: str = Field(
-        description="""The field name of the property, as provided in the included
-the auxiliary property files.
-Will be served with a provider-specific prefix in the actual API, so must not start with an underscore."""
+        description="""The field name of the property to use in the API. Will be searched for in the included
+the auxiliary property files, unless `aliases` is also specified.
+Will be served with a provider-specific prefix in the actual API, so must not start with an underscore or contain upper case characters.""",
+        pattern=IDENTIFIER_REGEX,
     )
 
     title: Optional[str] = Field(
@@ -38,8 +41,7 @@ Will be served with a provider-specific prefix in the actual API, so must not st
     unit: Optional[str] = Field(
         None, description="The unit of the property, e.g. 'eV' or 'Å'."
     )
-    type: Optional[str] = Field(
-        None,
+    type: Optional[DataType] = Field(
         description="The OPTIMADE type of the property, e.g., `float` or `string`.",
     )
     maps_to: Optional[str] = Field(

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -437,9 +437,13 @@ def _parse_and_assign_properties(
     expected_property_fields = set(property_def_dict.keys())
 
     if expected_property_fields != all_property_fields:
-        warnings.warn(
-            f"Found {all_property_fields=} in data but {expected_property_fields} in config"
-        )
+        warning_message = "Mismatch between parsed property fields (A) and those defined in config (B)."
+        if all_property_fields - expected_property_fields:
+            warning_message += f"\n(A - B) = {all_property_fields - expected_property_fields} (will be omitted from API; if intended this can be ignored)."
+        if expected_property_fields - all_property_fields:
+            warning_message += f"\n(B - A) = {expected_property_fields - all_property_fields} (configured, but missing; check for typos or missing aliases)"
+
+        warnings.warn(warning_message)
 
     # Look for precisely matching IDs, or 'filename' matches
     for id in optimade_entries:
@@ -466,7 +470,7 @@ def _parse_and_assign_properties(
                 property, None
             ) or parsed_properties.get(id, {}).get(property, None)
             if property not in property_def_dict:
-                warnings.warn(f"Missing property definition for {property=}")
+                # These are already warned about above: fields that are not configured but are present in the property file
                 continue
             if value is not None and property_def_dict[property].type in TYPE_MAP:
                 try:

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -399,6 +399,11 @@ def _parse_and_assign_properties(
     if not property_matches_by_file:
         return
 
+    optimade_immutable_ids = {
+        entry["attributes"].get("immutable_id")
+        for entry in optimade_entries.values()
+    }
+
     for archive_file in property_matches_by_file:
         for _path in tqdm.tqdm(
             property_matches_by_file[archive_file],
@@ -411,9 +416,9 @@ def _parse_and_assign_properties(
                     for id in properties:
                         parsed_properties[id].update(properties[id])
                         all_property_fields |= set(properties[id].keys())
-                        if id not in optimade_entries:
+                        if id not in optimade_entries and id not in optimade_immutable_ids:
                             warnings.warn(
-                                f"Could not find entry {id!r} in OPTIMADE entries. This warning can be ignored if the property file uses fully qualified IDs.",
+                                f"Could not find entry {id!r} in OPTIMADE entries.",
                             )
                             continue
                     break

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -400,8 +400,7 @@ def _parse_and_assign_properties(
         return
 
     optimade_immutable_ids = {
-        entry["attributes"].get("immutable_id")
-        for entry in optimade_entries.values()
+        entry["attributes"].get("immutable_id") for entry in optimade_entries.values()
     }
 
     for archive_file in property_matches_by_file:
@@ -416,7 +415,10 @@ def _parse_and_assign_properties(
                     for id in properties:
                         parsed_properties[id].update(properties[id])
                         all_property_fields |= set(properties[id].keys())
-                        if id not in optimade_entries and id not in optimade_immutable_ids:
+                        if (
+                            id not in optimade_entries
+                            and id not in optimade_immutable_ids
+                        ):
                             warnings.warn(
                                 f"Could not find entry {id!r} in OPTIMADE entries.",
                             )

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -89,6 +89,8 @@ def convert_archive(
 
     if not jsonl_path:
         jsonl_path = archive_path / "optimade.jsonl"
+    if jsonl_path.exists() and not overwrite:
+        raise RuntimeError(f"Not overwriting existing file at {jsonl_path}")
 
     # if the config specifies just a JSON-L, then extract any archives
     # and return the JSONL path

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -469,7 +469,12 @@ def _parse_and_assign_properties(
                 warnings.warn(f"Missing property definition for {property=}")
                 continue
             if value is not None and property_def_dict[property].type in TYPE_MAP:
-                value = TYPE_MAP[property_def_dict[property].type](value)
+                try:
+                    value = TYPE_MAP[property_def_dict[property].type](value)
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"Could not cast {value=} for {property=} to type {property_def_dict[property].type!r} for entry {id!r}"
+                    ) from exc
 
             optimade_entries[id]["attributes"][f"_{provider_prefix}_{property}"] = value
 

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -411,6 +411,11 @@ def _parse_and_assign_properties(
                     for id in properties:
                         parsed_properties[id].update(properties[id])
                         all_property_fields |= set(properties[id].keys())
+                        if id not in optimade_entries:
+                            warnings.warn(
+                                f"Could not find entry {id!r} in OPTIMADE entries. This warning can be ignored if the property file uses fully qualified IDs.",
+                            )
+                            continue
                     break
                 except Exception as exc:
                     errors.append(exc)
@@ -443,6 +448,14 @@ def _parse_and_assign_properties(
         if property_entry_id is None:
             # try to find a matching ID based on the filename
             property_entry_id = id.split("/")[-1].split(".")[0]
+
+        if (property_entry_id not in parsed_properties) and (
+            id not in parsed_properties
+        ):
+            warnings.warn(
+                f"Could not find entry {id!r} (or fully-qualified {property_entry_id!r}) in parsed properties",
+            )
+            continue
 
         # Loop over all defined properties and assign them to the entry, setting to None if missing
         # Also cast types if provided

--- a/src/optimade_maker/parsers.py
+++ b/src/optimade_maker/parsers.py
@@ -57,6 +57,7 @@ def load_csv_file(
         for alias in prop.aliases or []:
             if alias in df:
                 df[prop.name] = df[alias]
+                df.drop(columns=[alias], inplace=True)
                 break
 
     return df.to_dict(orient="index")

--- a/src/optimade_maker/parsers.py
+++ b/src/optimade_maker/parsers.py
@@ -13,7 +13,7 @@ except ImportError as exc:
     ) from exc
 
 from optimade.adapters import Structure
-from optimade.models import EntryResource
+from optimade.models import DataType, EntryResource
 
 from optimade_maker.config import PropertyDefinition
 
@@ -68,11 +68,11 @@ PROPERTY_PARSERS: dict[
     ".csv": [load_csv_file],
 }
 
-TYPE_MAP: dict[str | None, type] = {
-    "float": float,
-    "string": str,
-    "integer": int,
-    "boolean": bool,
+TYPE_MAP: dict[DataType, type] = {
+    DataType.FLOAT: float,
+    DataType.STRING: str,
+    DataType.INTEGER: int,
+    DataType.BOOLEAN: bool,
 }
 
 


### PR DESCRIPTION
- [x] Fail early if JSONL file exists and `--overwrite` unset
- [x] Add warnings if property files and entries do not match, to avoid case where no properties are attached to structures and the rest of the process succeeds (closes #74)
- [x] Improve the error message when a user specifies the wrong type for a property, and validate with OPTIMADE types
- [x] Improve warnings when property names do not match those found in property files