### PR TITLE
Update dependencies: ase, pandas as main; decouple pmg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install the minimum environment with testing
         run: |
-          uv sync --locked --dev
+          uv sync --locked --extra dev
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,21 +63,21 @@ jobs:
           version: "0.8.x"
           enable-cache: true
 
-      - name: Install latest compatible versions of immediate dependencies
+      - name: Install the minimum environment with testing
         run: |
-          uv sync --locked --all-extras --dev
+          uv sync --locked --dev
 
       - name: Run tests
         run: |
           uv run pytest -vv --cov=./src/optimade_maker --cov-report=xml --cov-report=term ./tests
 
-      - name: Reinstall environment without aiida
+      - name: Reinstall the full environment with all extras
         run: |
-          uv sync --locked --extra core --extra tests
+          uv sync --locked --all-extras --dev
 
-      - name: Rerun tests without aiida
+      - name: Rerun tests
         run: |
-          uv run pytest -vv --cov=./src/optimade_maker --cov-report=xml --cov-report=term ./tests --ignore=./tests/aiida
+          uv run pytest -vv --cov=./src/optimade_maker --cov-report=xml --cov-report=term ./tests
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ entries:
       - file: properties.csv
     property_definitions:
       - name: energy
-        title: Total energy per atom
-        description: DFT total energy per atom
+        title: Total energy
+        description: DFT total energy
         unit: eV/atom
         type: float
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install with
 
 ```bash
 pip install optimade-maker
-# or to get all extra plugins (e.g. pymatgen, aiida):
+# or to get all ingestion plugins (e.g. pymatgen, aiida):
 pip install optimade-maker[ingest]
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This repository contains the src/optimade-maker Python package and the correspon
 Install with
 
 ```bash
+pip install optimade-maker
+# or to get all extra plugins (e.g. pymatgen, aiida):
 pip install optimade-maker[ingest]
 ```
 

--- a/examples/simple_zip_of_cif/optimade.yaml
+++ b/examples/simple_zip_of_cif/optimade.yaml
@@ -12,7 +12,7 @@ entries:
       - file: properties.csv
     property_definitions:
       - name: energy
-        title: Total energy per atom
-        description: The total energy per atom as computed by DFT
+        title: Total energy
+        description: DFT total energy
         unit: eV/atom
         type: float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,15 @@ classifiers = [
 ]
 
 dependencies = [
-  "pydantic~=2.2",
-  "optimade[server]~=1.4.1",
-  "pymongo",
+  "pydantic>=2,<3",
+  "optimade[server]~=1.4",
+  "pymongo>=4,<5",
   "pyyaml~=6.0",
   "tqdm~=4.65",
   "requests~=2.31",
-  "numpy >= 1.22, < 3",
   "click~=8.1",
+  "pandas>=1.5,<3",
+  "ase~=3.22",
 ]
 
 [project.scripts]
@@ -41,14 +42,11 @@ fallback_version = "0.1.0"
 version_scheme = "post-release"
 
 [project.optional-dependencies]
-ase = ["ase ~= 3.22"]
 pymatgen = ["pymatgen >= 2023.9"]
-pandas = ["pandas >= 1.5, < 3"]
-aiida = ["aiida-core >= 2.6.3"]
-core = ["optimade-maker[ase,pymatgen,pandas]"]
-ingest = ["optimade-maker[ase,pymatgen,pandas,aiida]"]
-tests = ["pytest~=8.3", "pytest-cov~=6.0"]
-dev = ["ruff", "pre-commit", "mypy"]
+aiida = ["aiida-core ~= 2.6"]
+ingest = ["optimade-maker[pymatgen,aiida]"]
+tests = ["pytest~=8.3", "pytest-cov~=6.0", "numpy >= 1.22, < 3"]
+dev = ["optimade-maker[tests]", "ruff", "pre-commit", "mypy"]
 
 [tool.ruff]
 target-version = "py311"

--- a/src/optimade_maker/convert.py
+++ b/src/optimade_maker/convert.py
@@ -306,11 +306,11 @@ def _parse_entries(
                         entry_ids.append(id_root)
                     break
                 except Exception as exc:
-                    exceptions[parser] = exc
+                    exceptions[parser.__name__] = exc
                     continue
             else:
                 raise RuntimeError(
-                    f"None of the provided parsers {ENTRY_PARSERS[entry_type]} could parse {_path}. Errors: {exceptions}"
+                    f"None of the provided parsers could parse {_path}. Errors: {exceptions}"
                 )
 
     if len(set(entry_ids)) != len(entry_ids):

--- a/src/optimade_maker/parsers.py
+++ b/src/optimade_maker/parsers.py
@@ -3,19 +3,8 @@ import warnings
 from pathlib import Path
 from typing import Any, Callable
 
-import numpy as np
-
-try:
-    import ase.io
-    import pandas
-    import pymatgen.core
-    import pymatgen.entries.computed_entries
-    from pymatgen.entries.computed_entries import ComputedStructureEntry
-except ImportError as exc:
-    raise ImportError(
-        "The parsers module requires the `ingest` extra of this package to be installed."
-    ) from exc
-
+import ase.io
+import pandas
 from optimade.adapters import Structure
 from optimade.models import DataType, EntryResource
 
@@ -71,9 +60,7 @@ def load_csv_file(
             and prop_def.name in df.columns
         ):
             # Replace NaN -> "null"
-            df[prop_def.name] = (
-                df[prop_def.name].fillna(np.nan).replace({np.nan: "null"})
-            )
+            df[prop_def.name] = df[prop_def.name].fillna("null")
             try:
                 df[prop_def.name] = df[prop_def.name].apply(
                     lambda v: json.loads(v) if isinstance(v, str) else v
@@ -139,6 +126,29 @@ TYPE_MAP: dict[DataType, type] = {
 }
 
 
+ENTRY_PARSERS: dict[str, list[Callable[[Path], Any]]] = {
+    "structures": [ase.io.read],
+}
+
+
+def structure_ingest_wrapper(entry, prop_defs=None, prefix=None):  # type: ignore
+    return Structure.ingest_from(entry)
+
+
+OPTIMADE_CONVERTERS: dict[
+    str,
+    list[
+        Callable[
+            [Any, list[PropertyDefinition] | None, str | None], EntryResource | dict
+        ]
+    ],
+] = {
+    "structures": [structure_ingest_wrapper],
+}
+
+#### Wrappers for third-party parsers and converters, such as pymatgen ####
+
+
 def wrapped_json_parser(parser):
     """This wrapper allows `from_dict` parser functions to be called
     on a single JSON file.
@@ -174,19 +184,8 @@ def wrapped_json_parser(parser):
     return _wrapped_json_parser
 
 
-ENTRY_PARSERS: dict[str, list[Callable[[Path], Any]]] = {
-    "structures": [
-        ase.io.read,
-        wrapped_json_parser(
-            pymatgen.entries.computed_entries.ComputedStructureEntry.from_dict
-        ),
-        wrapped_json_parser(pymatgen.core.Structure.from_dict),
-    ],
-}
-
-
 def convert_pymatgen_computed_structure_entry(
-    pmg_entry: ComputedStructureEntry,
+    pmg_entry,
     prop_defs: list[PropertyDefinition] | None = None,
     prefix: str | None = None,
 ) -> dict:
@@ -213,17 +212,28 @@ def convert_pymatgen_computed_structure_entry(
     return entry
 
 
-def structure_ingest_wrapper(entry, prop_defs=None, prefix=None):  # type: ignore
-    return Structure.ingest_from(entry)
+def add_pymatgen_parsers():
+    try:
+        import pymatgen.core
+        import pymatgen.entries.computed_entries
+
+        ENTRY_PARSERS["structures"].extend(
+            [
+                wrapped_json_parser(
+                    pymatgen.entries.computed_entries.ComputedStructureEntry.from_dict
+                ),
+                wrapped_json_parser(pymatgen.core.Structure.from_dict),
+            ]
+        )
+
+        OPTIMADE_CONVERTERS["structures"].append(
+            convert_pymatgen_computed_structure_entry
+        )
+    except ImportError:
+        warnings.warn(
+            "pymatgen is not installed, so corresponding parsers and converters will not be available. "
+            "To use these, install the 'pymatgen' extra."
+        )
 
 
-OPTIMADE_CONVERTERS: dict[
-    str,
-    list[
-        Callable[
-            [Any, list[PropertyDefinition] | None, str | None], EntryResource | dict
-        ]
-    ],
-] = {
-    "structures": [structure_ingest_wrapper, convert_pymatgen_computed_structure_entry],
-}
+add_pymatgen_parsers()

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -10,6 +10,7 @@ from optimade.models import EntryInfoResource
 from optimade_maker.convert import convert_archive
 
 AIIDA_AVAILABLE = bool(importlib.util.find_spec("aiida"))
+PYMATGEN_AVAILABLE = bool(importlib.util.find_spec("pymatgen"))
 
 EXAMPLE_ARCHIVES = (Path(__file__).parent.parent / "examples").glob("*")
 
@@ -27,6 +28,10 @@ def test_convert_example_archives(archive_path, tmp_path):
     if "aiida" in archive_path.name and not AIIDA_AVAILABLE:
         pytest.skip(
             "Skipping test for AiiDA archive, as it requires AiiDA to be installed."
+        )
+    if "pymatgen" in archive_path.name and not PYMATGEN_AVAILABLE:
+        pytest.skip(
+            "Skipping test for pymatgen archive, as it requires pymatgen to be installed."
         )
     # copy example into temporary path
     tmp_path = tmp_path / archive_path.name

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -10,6 +10,7 @@ import pytest
 import requests
 
 AIIDA_AVAILABLE = bool(importlib.util.find_spec("aiida"))
+PYMATGEN_AVAILABLE = bool(importlib.util.find_spec("pymatgen"))
 
 EXAMPLE_ARCHIVES = (Path(__file__).parent.parent / "examples").glob("*")
 
@@ -39,6 +40,10 @@ def test_serve_example_archives(archive_path, tmp_path):
     if "aiida" in archive_path.name and not AIIDA_AVAILABLE:
         pytest.skip(
             "Skipping test for AiiDA archive, as it requires AiiDA to be installed."
+        )
+    if "pymatgen" in archive_path.name and not PYMATGEN_AVAILABLE:
+        pytest.skip(
+            "Skipping test for pymatgen archive, as it requires pymatgen to be installed."
         )
     # copy example into temporary path
     tmp_path = tmp_path / archive_path.name

--- a/uv.lock
+++ b/uv.lock
@@ -1391,9 +1391,10 @@ server = [
 name = "optimade-maker"
 source = { editable = "." }
 dependencies = [
+    { name = "ase" },
     { name = "click" },
-    { name = "numpy" },
     { name = "optimade", extra = ["server"] },
+    { name = "pandas" },
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "pyyaml" },
@@ -1405,51 +1406,42 @@ dependencies = [
 aiida = [
     { name = "aiida-core" },
 ]
-ase = [
-    { name = "ase" },
-]
-core = [
-    { name = "ase" },
-    { name = "pandas" },
-    { name = "pymatgen" },
-]
 dev = [
     { name = "mypy" },
+    { name = "numpy" },
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 ingest = [
     { name = "aiida-core" },
-    { name = "ase" },
-    { name = "pandas" },
     { name = "pymatgen" },
-]
-pandas = [
-    { name = "pandas" },
 ]
 pymatgen = [
     { name = "pymatgen" },
 ]
 tests = [
+    { name = "numpy" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "aiida-core", marker = "extra == 'aiida'", specifier = ">=2.6.3" },
-    { name = "ase", marker = "extra == 'ase'", specifier = "~=3.22" },
+    { name = "aiida-core", marker = "extra == 'aiida'", specifier = "~=2.6" },
+    { name = "ase", specifier = "~=3.22" },
     { name = "click", specifier = "~=8.1" },
     { name = "mypy", marker = "extra == 'dev'" },
-    { name = "numpy", specifier = ">=1.22,<3" },
-    { name = "optimade", extras = ["server"], specifier = "~=1.4.1" },
-    { name = "optimade-maker", extras = ["aiida", "ase", "pandas", "pymatgen"], marker = "extra == 'ingest'" },
-    { name = "optimade-maker", extras = ["ase", "pandas", "pymatgen"], marker = "extra == 'core'" },
-    { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.5,<3" },
+    { name = "numpy", marker = "extra == 'tests'", specifier = ">=1.22,<3" },
+    { name = "optimade", extras = ["server"], specifier = "~=1.4" },
+    { name = "optimade-maker", extras = ["aiida", "pymatgen"], marker = "extra == 'ingest'" },
+    { name = "optimade-maker", extras = ["tests"], marker = "extra == 'dev'" },
+    { name = "pandas", specifier = ">=1.5,<3" },
     { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pydantic", specifier = "~=2.2" },
+    { name = "pydantic", specifier = ">=2,<3" },
     { name = "pymatgen", marker = "extra == 'pymatgen'", specifier = ">=2023.9" },
-    { name = "pymongo" },
+    { name = "pymongo", specifier = ">=4,<5" },
     { name = "pytest", marker = "extra == 'tests'", specifier = "~=8.3" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = "~=6.0" },
     { name = "pyyaml", specifier = "~=6.0" },
@@ -1457,7 +1449,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tqdm", specifier = "~=4.65" },
 ]
-provides-extras = ["ase", "pymatgen", "pandas", "aiida", "core", "ingest", "tests", "dev"]
+provides-extras = ["pymatgen", "aiida", "ingest", "tests", "dev"]
 
 [[package]]
 name = "orjson"


### PR DESCRIPTION
As briefly discussed earlier, I

- set `ase` and `pandas` as main dependencies.

This allows one to run the CLI, main functionality, and most examples after just doing `pip install optimade-maker`. Before, these things didn't really work for the base install. 

- decouple `pymatgen` from the other parsers

As `pymatgen` could potentially be less stable than `ase`, I kept that as an optional dependency. But this required to adapt a bit the imports and  setup of `pymatgen` parsers/converters.

